### PR TITLE
Celluloid based animation #21

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -84,4 +84,5 @@ dependencies:
     - termcolor==1.1.0
     - typing-extensions==4.0.1
     - urllib3==1.26.7
+    - celluloid==0.2.0
 prefix: /home/gerardoduran/miniconda3/envs/jsl


### PR DESCRIPTION
# Description
Updated the code to utilize ```celluloid``` for animation of ```ekf_mlp_ani.py``` 

# Issue
#21

# Figures
https://user-images.githubusercontent.com/58566451/163026177-23a3ff4b-1f2d-49a5-b432-3a6f46f9454d.mp4

# Steps
- [x] Used the ```Camera``` class of ``` celluloid``` to save snapshots of the matplotlob figure
- [x] Changed the code to use ``` camera.animate``` instead of ``` matplotlib.FuncAnimation```

# Checklist
- [x] Performed a self review of the code
- [x] Tested successfully on Google Colab for GPU and CPU