### PR TITLE
Implement Fixed Lag Smoothing for an HMM

### DIFF
--- a/jsl/hmm/hmm_lib.py
+++ b/jsl/hmm/hmm_lib.py
@@ -37,7 +37,7 @@ jit, vmap and optimizers on the hidden markov model.
 
 @flax.struct.dataclass
 class HMMJax:
-    trans_mat: jnp.array  # A : (n_states, n_states)
+    trans_mat: jnp.array  # A : ((n_actions,) n_states, n_states) 
     obs_mat: jnp.array  # B : (n_states, n_obs)
     init_dist: jnp.array  # pi : (n_states)
 
@@ -314,6 +314,86 @@ def hmm_forwards_backwards_jax(params, obs_seq, length=None):
     # gamma = alpha * jnp.roll(beta, -seq_len + length, axis=0) #: Alternative
     gamma = vmap(lambda x: normalize(x)[0])(gamma)
     return alpha, beta, gamma, ll
+
+
+@partial(jit, static_argnums=(1))
+def fixed_lag_smoother(params, win_len, alpha_win, bmatrix_win, obs, act=None):
+    '''
+    Computes the smoothed posterior for each state in the lagged window of
+    fixed size, win_len.
+
+    Parameters
+    ----------
+    params      : HMMJax
+        Hidden Markov Model (with action-dependent transition)
+    
+    win_len     : int
+        Desired window length (>= 2)
+    
+    alpha_win   : array
+        Alpha values for the most recent win_len steps, excluding current step
+    
+    bmatrix_win : array
+        Beta transformations for the most recent win_len steps, excluding current step
+    
+    obs         : int
+        New observation for the current step
+    
+    act         : array
+        (optional) Actions for the most recent win_len steps, including current step
+    
+    Returns
+    -------
+    * array(win_len, n_states)
+        Updated alpha values
+    
+    * array(win_len, n_states)
+        Updated beta transformations
+    
+    * array(win_len, n_states)
+        Smoothed posteriors for the past d steps
+    '''
+    if len(alpha_win.shape) < 2:
+        alpha_win = jnp.expand_dims(alpha_win, axis=0)
+    curr_len = alpha_win.shape[0]
+    win_len = min(win_len, curr_len+1)
+    assert win_len >= 2, "Must keep a window of length at least 2."
+
+    trans_mat, obs_mat = params.trans_mat, params.obs_mat
+    n_states, n_obs = obs_mat.shape
+    
+    # If trans_mat is independent of action, adjust shape
+    if len(trans_mat.shape) < 3:
+        trans_mat = jnp.expand_dims(trans_mat, axis=0)
+        act = None
+    if act is None:
+        act = jnp.zeros(shape=(curr_len+1,), dtype=jnp.int8)
+
+    # Shift window forward by 1
+    if curr_len == win_len:
+        alpha_win = alpha_win[1:]
+        bmatrix_win = bmatrix_win[1:]
+        
+    # Perform one forward operation
+    new_alpha, _ = normalize(
+        obs_mat[:, obs] * (alpha_win[-1][:, None] * trans_mat[act[-1]]).sum(axis=0)
+    )
+    alpha_win = jnp.concatenate((alpha_win, new_alpha[None, :]))
+
+    # Smooth inside the window in parallel
+    def update_bmatrix(bmatrix):
+        return (bmatrix @ trans_mat[act[-2]]) * obs_mat[:, obs]
+    bmatrix_win = vmap(update_bmatrix)(bmatrix_win)
+    bmatrix_win = jnp.concatenate((bmatrix_win, jnp.eye(n_states)[None, :]))
+    
+    # Compute beta values by row-summing bmatrices
+    def get_beta(bmatrix):
+        return normalize(bmatrix.sum(axis=1))[0]
+    beta_win = vmap(get_beta)(bmatrix_win)
+    
+    # Compute posterior values
+    gamma_win, _ = normalize(alpha_win * beta_win, axis=1)
+    return alpha_win, bmatrix_win, gamma_win
 
 
 @jit

--- a/jsl/hmm/hmm_lib.py
+++ b/jsl/hmm/hmm_lib.py
@@ -62,7 +62,7 @@ def normalize(u, axis=0, eps=1e-15):
         The values of the normalizer
     '''
     u = jnp.where(u == 0, 0, jnp.where(u < eps, eps, u))
-    c = u.sum(axis=axis)
+    c = u.sum(axis=axis, keepdims=True)
     c = jnp.where(c == 0, 1, c)
     return u / c, c
 


### PR DESCRIPTION
## Description
Implemented Fixed Lag Smoothing for an HMM.
A modern, vectorized, JAX-ified update to [Kevin Murphy's HMM Toolbox for Matlab](https://www.cs.ubc.ca/~murphyk/Software/HMM/hmm.html).

My contributions and modifications to the original implementation are as follows:

1. Fixed "incompatible shapes for broadcasting" error for JSL's `normalize` function applied to rectangular matrices with `axis=1` by adding `keepdims=True` to the denominator.
2. Implemented a vectorized version of `fixed_lag_smoother` in `hmm_lib.py` that computes the smoothed posterior for each state in the lagged window of fixed size.
3. Added a unit test to `hmm_lib_test.py` that demonstrates that the results of a fully-lagged `fixed_lag_smoother` matches that of JSL's implementation of `hmm-forwards_backwards_jax`.

Note that the implementation differs from the Matlab code in the following ways:

1. The time-step dimension has been changed to `axis=0` for stylistic consistency with JSL (i.e., the shape for `gamma` is now `(win_len, num_states)`)
2. We no longer compute the intermediate joint distribution `xi(i,j,t)` but instead directly compute the `alpha` values by applying a single forward operation to the previous `alpha` value.
3. **Instead of iteratively smoothing backwards inside the window, we now apply a single vectorized operation `update_bmatrix`. This is done by passing the backwards transformation operator `bmatrix` itself, rather than its row sum `beta` (since row sum is non-invertible) and after updating the window of `bmatrix_win`, we can apply the vectorized row-sum operator `get_beta` to compute the beta values all at once. This leads to significant speed-up (exponential in the size of window), as demonstrated in the Figures below.**
4. We use a single instance of the new observation instead of keeping track of past observation likelihoods `obslik`. This is made possible by manipulating the vectorized `bmatrix_win` instead of iterative `beta`.
5. We assume constant observation likelihood (see Limitations below).

## Colab Link
In the Colab version, I implemented a more direct, iterative translation of the Matlab version, `fixed_lag_smoother_iterative` for performance comparison.

https://colab.research.google.com/github/peterchang0414/hmm-jax/blob/main/fixed_lag_smoother.ipynb


## Issue
[#736: Implement Fixed Lag Smoothing for an HMM](https://github.com/probml/pyprobml/issues/736)

## Figures
[Gist for results of timed experiments between iterative vs vectorized implementations](https://gist.github.com/peterchang0414/cae5b7d6597fd077fa8ca875e8e81bfc)
Uncached speed-up of vectorized vs iterative approach as a function of window size:
![unjitted_perf_comp_iter_vs_vec_fls](https://raw.githubusercontent.com/peterchang0414/hmm-jax/main/unjitted_performance_comparison.png)

## Checklist:

- [x] Performed a self-review of the code
- [x] Tested on Google Colab.

## Limitations:
Despite the Matlab version's flexibility with the likelihood model, I chose my implementation to work under the simplifying assumption of unchanging, constant likelihood model across the time steps. This was done for consistency with the framework used in the JSL library which directly encodes the observation likelihood matrix into the `HMMJax` dataclass, but if needed, I can, without difficulty, make further adjustments to allow flexible likelihood model. 
