### PR TITLE
Kalman filter fix

### DIFF
--- a/jsl/lds/kalman_filter_test.py
+++ b/jsl/lds/kalman_filter_test.py
@@ -1,0 +1,66 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+
+from jax import random
+from jax import numpy as jnp
+import numpy as np
+import tensorflow as tf
+import tensorflow_probability as tfp
+
+tfd = tfp.distributions
+from kalman_filter import LDS, kalman_filter
+
+def tfp_filter(timesteps, A, transition_noise_scale, C, observation_noise_scale, mu0, x_hist):
+    """ Perform filtering using tensorflow probability """
+    state_size, _ = A.shape
+    observation_size, _ = C.shape
+    transition_noise = tfd.MultivariateNormalDiag(
+        scale_diag=jnp.ones(state_size) * transition_noise_scale
+    )
+    obs_noise = tfd.MultivariateNormalDiag(
+        scale_diag=jnp.ones(observation_size) * observation_noise_scale
+    )
+    prior = tfd.MultivariateNormalDiag(mu0, tf.ones([state_size]))
+
+    LGSSM = tfd.LinearGaussianStateSpaceModel(
+        timesteps, A, transition_noise, C, obs_noise, prior
+    )
+
+    _, filtered_means, filtered_covs, _, _, _, _ = LGSSM.forward_filter(x_hist)
+    return filtered_means.numpy(), filtered_covs.numpy()
+
+
+def test_kalman_filter():
+    key = random.PRNGKey(314)
+    timesteps = 15 
+    delta = 1.0
+
+    ### LDS Parameters ###
+    state_size = 2
+    observation_size = 2
+    A = jnp.eye(state_size)
+    C = jnp.eye(state_size)
+
+    transition_noise_scale = 1.0
+    observation_noise_scale = 1.0
+    Q = jnp.eye(state_size) * transition_noise_scale
+    R = jnp.eye(observation_size) * observation_noise_scale
+
+
+    ### Prior distribution params ###
+    mu0 = jnp.array([8, 10]).astype(float)
+    Sigma0 = jnp.eye(state_size) * 1.0
+
+    ### Sample data ###
+    lds_instance = LDS(A, C, Q, R, mu0, Sigma0)
+    z_hist, x_hist = lds_instance.sample(key, timesteps)
+
+    JSL_z_filt, JSL_Sigma_filt, _, _ = kalman_filter(lds_instance, x_hist)
+    tfp_z_filt, tfp_Sigma_filt = tfp_filter(
+        timesteps, A, transition_noise_scale, C, observation_noise_scale, mu0, x_hist
+    )
+
+    assert np.allclose(JSL_z_filt, tfp_z_filt, rtol=1e-2)
+    assert np.allclose(JSL_Sigma_filt, tfp_Sigma_filt, rtol=1e-2)
+


### PR DESCRIPTION
At present it there is a discrepancy between the filtering from `jsl.lds.kalman_filter` and the [tfp implementation](https://www.tensorflow.org/probability/api_docs/python/tfp/distributions/LinearGaussianStateSpaceModel). The JSL filtering results are consistently putting more weight on the first observation (x_0) relative to the prior mean (\mu_0) in comparison to the tfp implementation.  Shown in the figure below:

<img src="https://user-images.githubusercontent.com/13415723/168862740-9ff24cb6-10da-43f7-a0e8-f099220dfa26.png" alt="kalman filter bug" width="600"/>

This effect is also seen in the results of maheswarantp in Issue #41.

I think it might be happening because the current implementation is taking into account the transition noise when calculating the posterior of the initial hidden state which is unnecessary. 

In kalman-filter-fix branch I have refactored the kalman filter code to split the `kalman_step()` into `kalman_predict()` and `kalman_update()`. `kalman_filter()` is updated so that the first time point only uses `kalman_update()`. 

It looks like this has fixed the problem:

<img src="https://user-images.githubusercontent.com/13415723/168862766-b2b1becf-567d-49a0-95ad-504c95de4d66.png" alt="kalman filter bug" width="600"/>

I have also written a basic test, in [kalman_filter_test.py](https://github.com/probml/JSL/blob/352f367526ef0fdee685c799567252310370f7c2/jsl/lds/kalman_filter_test.py) to test for differences between JSL and tfp. This test fails on the main branch but passes with the present fix.
